### PR TITLE
Expanded windows driver instructions

### DIFF
--- a/windows driver/AVT_signed/windows-driver-signing.txt
+++ b/windows driver/AVT_signed/windows-driver-signing.txt
@@ -5,6 +5,9 @@ Following commands must be run with elevated command prompt, to add certificates
 	certutil.exe -enterprise -addstore Root rootcert-AVTroot.cer
 	certutil.exe -enterprise -addstore CA intercert-AVTadmin.cer
 
+Recommended way of doing this is to copy the certificates to c:\windows\system32 and then from an administrative command
+prompt run the above commands.
+
 After this, the signing certificate "Marc Hefter - codesign" is accepted as valid.
 
 some additional notes:
@@ -13,3 +16,4 @@ some additional notes:
 *	After creating/signing the catalog file, the inf MUST NOT be modified, or signature gets invalid
 *	if adding the certificates with "certificate import assistant" (by double clicking in explorer), choose
 	local machine as store location instead of current user.
+


### PR DESCRIPTION
As seen in http://rfidler.org/index.php?p=/discussion/302/installing-on-windows-8.  I couldn't get this to work until I copied the certs into windows\system32.